### PR TITLE
Allow MobjThinker, TouchSpecial and PlayerCmd hooks to be overridable

### DIFF
--- a/xItemSrc/xItemLib_v112.lua
+++ b/xItemSrc/xItemLib_v112.lua
@@ -2691,22 +2691,22 @@ if not xItemLib then
 		end
 	end)
 
-	addHook("PlayerCmd", xItemLib.func.playerCmdHook)
+	addHook("PlayerCmd", function(p, cmd) xItemLib.func.playerCmdHook(p, cmd) end)
 
 	--dropped item behaviour
-	addHook("MobjThinker", xItemLib.func.floatingItemThinker, MT_FLOATINGITEM)
+	addHook("MobjThinker", function(mo) xItemLib.func.floatingItemThinker(mo) end, MT_FLOATINGITEM)
 
-	addHook("TouchSpecial", xItemLib.func.floatingItemSpecial, MT_FLOATINGITEM)
+	addHook("TouchSpecial", function(s, t) xItemLib.func.floatingItemSpecial(s, t) end, MT_FLOATINGITEM)
 
-	addHook("TouchSpecial", xItemLib.func.itemBoxSpecial, MT_RANDOMITEM)
+	addHook("TouchSpecial", function(s, t) xItemLib.func.itemBoxSpecial(s, t) end, MT_RANDOMITEM)
 	
-	addHook("MobjThinker", xItemLib.func.floatingXItemThinker, MT_FLOATINGXITEM)
+	addHook("MobjThinker", function(mo) xItemLib.func.floatingXItemThinker(mo) end, MT_FLOATINGXITEM)
 
-	addHook("TouchSpecial", xItemLib.func.floatingXItemSpecial, MT_FLOATINGXITEM)
+	addHook("TouchSpecial", function(s, t) xItemLib.func.floatingXItemSpecial(s, t) end, MT_FLOATINGXITEM)
 	
-	addHook("MobjThinker", xItemLib.func.playerArrowThinker, MT_XITEMPLAYERARROW)
+	addHook("MobjThinker", function(mo) xItemLib.func.playerArrowThinker(mo) end, MT_XITEMPLAYERARROW)
 	
-	addHook("MobjThinker", xItemLib.func.vanillaArrowThinker, MT_PLAYERARROW)
+	addHook("MobjThinker", function(mo) xItemLib.func.vanillaArrowThinker(mo) end, MT_PLAYERARROW)
 
 	xItemLib.func.addItem{"KITEM_SNEAKER", "Sneaker", "K_ITSHOE", "K_ISSHOE", vanillaItemProps["KITEM_SNEAKER"].flags, vanillaItemProps["KITEM_SNEAKER"].raceodds, vanillaItemProps["KITEM_SNEAKER"].battleodds, nil, nil, nil, nil, nil, {0, {SPR_ITEM, 1}}, true, nil, nil}
 	xItemLib.func.addItem{"KITEM_ROCKETSNEAKER", "Rocket Sneaker", "K_ITRSHE", "K_ISRSHE", vanillaItemProps["KITEM_ROCKETSNEAKER"].flags, vanillaItemProps["KITEM_ROCKETSNEAKER"].raceodds, vanillaItemProps["KITEM_ROCKETSNEAKER"].battleodds, nil, nil, nil, nil, nil, {0, {SPR_ITEM, 2}}, true, nil, nil}


### PR DESCRIPTION
# Summary
This change allows these hooks to be properly override-able:
```Lua
xItemLib.func.playerCmdHook
xItemLib.func.floatingItemThinker
xItemLib.func.floatingItemSpecial
xItemLib.func.itemBoxSpecial
xItemLib.func.floatingXItemThinker
xItemLib.func.floatingXItemSpecial
xItemLib.func.playerArrowThinker
xItemLib.func.vanillaArrowThinker
```
## Why
`xItemLib.func.playerThinker` and `xItemLib.func.hudMain` are overridable already, and this extends XItemLib's flexibility.

My use case for needing the rest to be override-able was that I also needed to make a disable toggle, and having vanilla item logic but XItem floating items caused some weird side effects.

## Testing
Run this as a Lua script, it should disable the entirety of XItemLib:
```Lua
	local stub = function() end

	xItemLib.func.playerThinker = stub
	xItemLib.func.playerCmdHook = stub
	xItemLib.func.floatingItemThinker = stub
	xItemLib.func.floatingItemSpecial = stub
	xItemLib.func.itemBoxSpecial = stub
	xItemLib.func.floatingXItemThinker = stub
	xItemLib.func.floatingXItemSpecial = stub
	xItemLib.func.playerArrowThinker = stub
	xItemLib.func.vanillaArrowThinker = stub
	xItemLib.func.hudMain = stub
```
