### PR TITLE
Vanilla Player Arrow interoperability to preserve player references

### DIFF
--- a/extensions/xitem_playerarrowinterop.lua
+++ b/extensions/xitem_playerarrowinterop.lua
@@ -1,0 +1,83 @@
+-- Optimization.
+local G_BattleGametype = G_BattleGametype
+local P_SpawnMobj = P_SpawnMobj
+local pairs = pairs
+-- No more.
+
+local xitemHooked = false
+
+local VERSION = 2
+local ARROWS_NAMESPACE = "PLAYERARROWS"
+
+if restorePlayerVariables == nil then
+	rawset(_G, "restorePlayerVariables", {})
+end
+
+local function anyVariablesOnApply()
+	local overrideArrow = false
+	
+	for key, func in pairs(restorePlayerVariables) do
+		if not func() then continue end
+		overrideArrow = true
+		break
+	end
+		
+	return overrideArrow
+end
+
+local function xitemHandler()
+	if xitemHooked then return end
+	if not (xItemLib and xItemLib.func) then return end
+	local lib = xItemLib.func
+	local modData = xItemLib.xItemCrossData.modData
+	
+	if modData[ARROWS_NAMESPACE] and modData[ARROWS_NAMESPACE].defDat.ver > VERSION then 
+		-- Exit early, don't attempt to add this again.
+		xitemHooked = true
+		return
+	end
+	
+	restorePlayerVariables["JBspy"] = function()
+		return JUICEBOX and JUICEBOX.value
+	end
+	restorePlayerVariables["FRoverhead"] = function()
+		local var = CV_FindVar("fr_enabled")
+		return var and var.value
+	end
+
+	lib.addXItemMod(ARROWS_NAMESPACE, "Player Arrows Fix for various mods", 
+	{
+		lib = "Player Arrows Fix for various mods - XItem interop by JugadorXEI",
+		ver = VERSION,
+		-- Fixes XItem stealing the Player Arrow references creating an infinite loop.
+		playerArrowSpawn = function(arrowMo, playerMo)
+			if not anyVariablesOnApply() then return end
+			if G_BattleGametype() then return end
+			local player = playerMo.player
+			if not player then return end
+
+			local f = P_SpawnMobj(arrowMo.x, arrowMo.y, arrowMo.z, MT_XITEMPLAYERARROW)
+			f.threshold = arrowMo.threshold
+			f.movecount = arrowMo.movecount
+			f.flags = arrowMo.flags
+			f.flags2 = arrowMo.flags2
+			f.target = arrowMo.target
+			f.scale = arrowMo.scale
+			f.destscale = arrowMo.destscale
+			f.state = arrowMo.state
+			for key, func in pairs(restorePlayerVariables) do
+				if not func() then continue end
+				player[key] = f
+			end
+			
+			-- This results in two MT_XITEMPLAYERARROWs being created,
+			-- but for the one we create at least the references are preserved.
+			return true
+		end
+	})
+
+	xitemHooked = true
+end
+
+addHook("MapLoad", xitemHandler)
+addHook("NetVars", xitemHandler)


### PR DESCRIPTION
# Summary
This interoperability script allows addons that use player arrows with their own player references to work properly with xItemLib.

## Why
When xItemLib creates its own player arrows, it doesn't preserve references other than what's needed in a vanilla context. But for other mods, since what they see is that the vanilla arrow got removed, they will recreate it again, over and over again until the game dramatically slows down.

This script fixes this issue so xItemLib can be used in tandem with JuiceBox and FriendMod.

This script technically has a bug, in that since there is no player arrow hook that gets the result of the xItem player arrow (that is, the `MT_XITEMPLAYERARROW` object), it will create two `MT_XITEMPLAYERARROW` objects instead, one having its proper references (the one made by this script) and one without (the one made by xitem). Ideally there should be a hook that allows you to set these references directly without having to create a new object to do it, but this is good enough.

(Maybe an even better fix would be to simply change the mobj type directly within the xItem library instead of having to create a new object, but I'm unsure of the side-effects here.)

## Testing
Simply leave xItemLib, this script and JuiceBox and/or Friendmod running with as many players as possible. Performance should not degrade anymore.