### PR TITLE
Guava Juicebox Interop (fixes Triple Sneakers, 3 -> 2)

### DIFF
--- a/extensions/xitem_juiceboxinterop.lua
+++ b/extensions/xitem_juiceboxinterop.lua
@@ -1,0 +1,48 @@
+-- The optimization momento certificado.
+local k_itemamount = k_itemamount
+local min = min
+-- No more opti.
+
+local xitemHooked = false
+
+local VERSION = 3
+local JB_NAMESPACE = "JUICEBOX"
+
+local function xitemHandler()
+	if xitemHooked then return end
+	if not (xItemLib and xItemLib.func) then return end
+	local lib = xItemLib.func
+	local modData = xItemLib.xItemCrossData.modData
+	
+	if modData[JB_NAMESPACE] and modData[JB_NAMESPACE].defDat.ver > VERSION then 
+		-- Exit early, don't attempt to add this again.
+		xitemHooked = true
+		return
+	end
+
+	lib.addXItemMod(JB_NAMESPACE, "Juicebox", 
+	{
+		lib = "By Tyron - XItem interop by JugadorXEI",
+		ver = VERSION,
+	})
+	
+	-- This NEEDS to have a function, otherwise the getfunc hook for this doesn't work.
+	local tripleSneakersFunc = lib.getItemDataById(KRITEM_TRIPLESNEAKER)["getfunc"]
+	if not tripleSneakersFunc then lib.getItemDataById(KRITEM_TRIPLESNEAKER)["getfunc"] = function(p, getitem) end end
+	
+	lib.getXItemModData(JB_NAMESPACE, KRITEM_TRIPLESNEAKER)["getfunc"] = function(player, item)
+		if G_BattleGametype() then return end
+		if not (JUICEBOX and JUICEBOX.value) then return end
+		if item ~= KRITEM_TRIPLESNEAKER then return end -- Just in case.
+		
+		-- Only for getting items through roulette, dropped/debug items are fine.
+		if xItemLib.toggles.debugItem > 0 then return end 
+		
+		player.kartstuff[k_itemamount] = min(2, $)
+	end
+
+	xitemHooked = true
+end
+
+addHook("MapLoad", xitemHandler)
+addHook("NetVars", xitemHandler)


### PR DESCRIPTION
# Summary
This is a script that preserves Juicebox's Triple Sneakers balance change, by giving the player 2 sneakers instead.

## Why
Three Sneakers are very strong in the context of Juicebox and this script aims to preserve that balance.
This script is separate from the [xItem_JuiceboxCompat.lua](https://github.com/minenice55/xItemLib/blob/main/extensions/xItem_JuiceboxCompat.lua) file as this works with the vanilla version of Juicebox instead of a modified version.

## Testing
* Load [Juicebox](https://mb.srb2.org/addons/juicebox.2691/), xItemLib and this script. Optionally also load the [Player Arrows interop script](https://github.com/minenice55/xItemLib/pull/7) from this branch so Juicebox doesn't slow down to a crawl. 
* `togglexitem` to toggle off all items, then `togglexitem "Triple Sneakers"` to only get Triple Sneakers.
* After picking an item box, you'll receive two sneakers.